### PR TITLE
ignore blacklisted people

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ async function handleMessage(message) {
   if (!valid) {
     switch (status) {
       case 'blacklisted':
-        return message.react('🚫');
+        return;
       case 'throttled':
         if (message.guild) {
           return message.react('⏱');


### PR DESCRIPTION
I feel that people who have been blacklisted are often done so for abusing the bot and should not be given any attention, especially since every time the bot does something it is closer to reaching its limit and the reaction could easily be abused.